### PR TITLE
Use webpki roots

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ name = "acceptxmr"
 path = "src/lib.rs"
 
 [dependencies]
-bincode = { version = "^2.0.0-rc.2", optional = true }
+bincode = { version = "^2.0.0-rc.3", optional = true }
 hex = "0.4"
 http = "0.2"
 hyper = { version = "0.14", features = ["client", "http1", "http2", "tcp"] }
-hyper-rustls = { version = "0.23", features = ["http2"] }
+hyper-rustls = { version = "0.24", features = ["logging", "http1", "http2", "tls12", "webpki-tokio"], default-features = false }
 indexmap = "1"
 log = "0.4"
 md-5 = "0.10"

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -47,7 +47,7 @@ impl RpcClient {
         hyper_connector.set_connect_timeout(Some(connection_timeout));
         hyper_connector.enforce_http(false);
         let rustls_connector = HttpsConnectorBuilder::new()
-            .with_native_roots()
+            .with_webpki_roots()
             .https_or_http()
             .enable_http1()
             .enable_http2()


### PR DESCRIPTION
Use mozilla webpki roots instead of native roots to improve portability.