### PR TITLE
Remove unnecessary clippy allows

### DIFF
--- a/src/payment_gateway.rs
+++ b/src/payment_gateway.rs
@@ -100,7 +100,7 @@ impl<S: InvoiceStorage + 'static> PaymentGateway<S> {
     ///
     /// * Returns an [`AcceptXmrError::Threading`] error if there was an error
     ///   creating the scanning thread.
-    #[allow(clippy::range_plus_one, clippy::missing_panics_doc)]
+    #[allow(clippy::range_plus_one)]
     pub async fn run(&self) -> Result<(), AcceptXmrError<S::Error>> {
         // Determine if the scanning thread is already running.
         {
@@ -269,7 +269,6 @@ impl<S: InvoiceStorage + 'static> PaymentGateway<S> {
     ///
     /// Returns an error if there are any underlying issues modifying data in
     /// the database.
-    #[allow(clippy::unused_async)]
     pub fn new_invoice(
         &self,
         piconeros: u64,
@@ -657,7 +656,7 @@ pub(crate) enum MessageToScanner {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use log::LevelFilter;
 
@@ -689,7 +688,7 @@ mod tests {
         )
         .daemon_url("http://example.com:18081".to_string())
         .build()
-        .expect("failed to build payment gateway");
+        .unwrap();
 
         assert_eq!(
             payment_gateway.rpc_client.url(),

--- a/src/rpc/authentication.rs
+++ b/src/rpc/authentication.rs
@@ -285,7 +285,6 @@ impl Algorithm {
     }
 }
 
-#[allow(clippy::module_name_repetitions)]
 #[derive(Error, Debug)]
 pub enum AuthError {
     #[error("unauthorized")]
@@ -299,9 +298,8 @@ pub enum AuthError {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
-    #![allow(clippy::expect_used)]
-
     use hyper::{
         header::{HeaderValue, WWW_AUTHENTICATE},
         Method, Response, Uri,
@@ -312,7 +310,7 @@ mod tests {
     #[test]
     fn test_parse_header() {
         let header = "Digest qop=\"auth\",algorithm=MD5-sess,realm=\"monero-rpc\", nonce=\"kVmRYw+lSQ80tTK3zj6/aA==\", stale=false";
-        let auth_params = parse_header(header).expect("failed to parse header");
+        let auth_params = parse_header(header).unwrap();
         let expected_auth_params = AuthParams {
             realm: "monero-rpc".to_string(),
             qop: vec![Qop::Auth],
@@ -332,14 +330,14 @@ mod tests {
         );
         let response = Response::builder()
             .header(WWW_AUTHENTICATE, "Digest qop=\"auth\",algorithm=MD5,realm=\"monero-rpc\",nonce=\"JmNFnqfRJdOr/vFZ2CpDQg==\",stale=false")
-            .body(()).expect("wailed to build WWW_AUTHENTICATE response");
+            .body(()).unwrap();
         let authorization_header = auth_info
             .authenticate_with_resp(
                 &response,
                 &Uri::from_static("https://busyboredom.com:18089/json_rpc"),
                 &Method::POST,
             )
-            .expect("failed to create AUTHORIZATION header");
+            .unwrap();
         assert_eq!(authorization_header, HeaderValue::from_static("Digest username=\"test user\", realm=\"monero-rpc\", nonce=\"JmNFnqfRJdOr/vFZ2CpDQg==\", uri=\"/json_rpc\", qop=auth, nc=00000001, cnonce=\"611830d3641a68f94a690dcc25d1f4b0\", response=\"af7810760defeed31054108ed35d400d\", algorithm=MD5"));
     }
 
@@ -353,14 +351,14 @@ mod tests {
         let response = Response::builder()
             .header(WWW_AUTHENTICATE, "Digest qop=\"auth\",algorithm=MD5,realm=\"monero-rpc\",nonce=\"JmNFnqfRJdOr/vFZ2CpDQg==\",stale=false")
             .header(WWW_AUTHENTICATE, "Digest qop=\"auth\",algorithm=MD5-sess,realm=\"monero-rpc\",nonce=\"JmNFnqfRJdOr/vFZ2CpDQg==\",stale=false")
-            .body(()).expect("wailed to build WWW_AUTHENTICATE response");
+            .body(()).unwrap();
         let authorization_header = auth_info
             .authenticate_with_resp(
                 &response,
                 &Uri::from_static("https://busyboredom.com:18089/json_rpc"),
                 &Method::POST,
             )
-            .expect("failed to create AUTHORIZATION header");
+            .unwrap();
         assert_eq!(authorization_header, HeaderValue::from_static("Digest username=\"test user\", realm=\"monero-rpc\", nonce=\"JmNFnqfRJdOr/vFZ2CpDQg==\", uri=\"/json_rpc\", qop=auth, nc=00000001, cnonce=\"611830d3641a68f94a690dcc25d1f4b0\", response=\"b0a351e720384a0160042ff2898ab24a\", algorithm=MD5-sess"));
     }
 
@@ -374,14 +372,14 @@ mod tests {
         let response = Response::builder()
             .header(WWW_AUTHENTICATE, "Digest qop=\"auth\",algorithm=MD5,realm=\"monero-rpc\",nonce=\"JmNFnqfRJdOr/vFZ2CpDQg==\",stale=false")
             .header(WWW_AUTHENTICATE, "Digest qop=\"auth\",algorithm=MD5-sess,realm=\"monero-rpc\",nonce=\"JmNFnqfRJdOr/vFZ2CpDQg==\",stale=false,opaque=5PCCDS2k5PCCDS2k")
-            .body(()).expect("wailed to build WWW_AUTHENTICATE response");
+            .body(()).unwrap();
         let authorization_header = auth_info
             .authenticate_with_resp(
                 &response,
                 &Uri::from_static("https://busyboredom.com:18089/json_rpc"),
                 &Method::POST,
             )
-            .expect("failed to create AUTHORIZATION header");
+            .unwrap();
         assert_eq!(authorization_header, HeaderValue::from_static("Digest username=\"test user\", realm=\"monero-rpc\", nonce=\"JmNFnqfRJdOr/vFZ2CpDQg==\", uri=\"/json_rpc\", qop=auth, nc=00000001, cnonce=\"611830d3641a68f94a690dcc25d1f4b0\", response=\"b0a351e720384a0160042ff2898ab24a\", algorithm=MD5-sess, opaque=5PCCDS2k5PCCDS2k"));
     }
 }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -284,7 +284,6 @@ impl RpcClient {
     }
 }
 
-#[allow(clippy::module_name_repetitions)]
 #[derive(Error, Debug)]
 pub enum RpcError {
     #[error("HTTP request failed: {0}")]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -197,7 +197,7 @@ mod test {
             .prefix("temp_db_")
             .rand_bytes(16)
             .tempdir()
-            .expect("failed to generate temporary directory")
+            .unwrap()
             .path()
             .to_str()
             .expect("failed to get temporary directory path")

--- a/src/storage/stores/sqlite.rs
+++ b/src/storage/stores/sqlite.rs
@@ -299,7 +299,6 @@ pub enum SqliteStorageError {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod test {
     use test_case::test_case;
 


### PR DESCRIPTION
# Description
Remove clippy allows that don't do anything.

Also removes some `.expect`s on `Result`s in tests that could just be `.unwrap`d. 

# Checklist
- [x] Link relevant issue(s).
- [x] Manually test the change.
- [x] Ensure sufficient automated test coverage.
- [x] Update the README.md if necessary.
- [x] Update the CHANGELOG.md if necessary.