### PR TITLE
Build docs with feature flag tags for docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/lib.rs"
 
 [package.metadata.docs.rs]
 all-features = true
+rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 bincode = { version = "^2.0.0-rc.3", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,8 @@
 #![warn(clippy::expect_used)]
 #![allow(clippy::multiple_crate_versions)]
 #![allow(clippy::module_name_repetitions)]
+// Show feature flag tags on `docs.rs`
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod caching;
 mod invoice;


### PR DESCRIPTION
Follow up to https://github.com/busyboredom/acceptxmr/pull/59.

This enables those cool feature flag tags, only for https://docs.rs, e.g:

![example](https://user-images.githubusercontent.com/101352116/235004615-3799a27c-3df8-4fb4-845c-ac17213e2023.png)

This feature is nightly only but:
- It's only enabled for docs.rs
- docs.rs uses a nightly compiler

To show the tags locally you can use:
```
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
```