### PR TITLE
Fix TX scanning for multiple owned outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ Book](https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field)
 ### Fixed
 - `Invoice`'s `expiration_in()` function returning expiration height instead of
   block difference when called before first scan.
-- Documentation not getting built with all features on docs.rs -- 
+- Documentation not getting built with all features on docs.rs --
   [@hinto-janai](https://www.github.com/hinto-janai)
+- Only considering amount of first owned output --
+  [@spirobel]((https://www.github.com/spirobel))
 
 ## [0.12.0] - 2023-03-18
 

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -369,7 +369,7 @@ impl<S: InvoiceStorage> Scanner<S> {
                 {
                     let amount = OwnedAmount {
                         sub_index,
-                        amount: transfers[0]
+                        amount: transfer
                             .amount()
                             .ok_or(AcceptXmrError::<S::Error>::Unblind(sub_index))?,
                     };


### PR DESCRIPTION
# Description
Fix scanning to consider the amount for each owned output, not just the first.

# Checklist
- [x] Link relevant issue(s).
- [x] Manually test the change.
- [ ] Ensure sufficient automated test coverage.
- [x] Update the README.md if necessary.
- [x] Update the CHANGELOG.md if necessary.