### PR TITLE
Update MSRV to 1.68

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         rust: [
-          1.65.0,
+          1.68.0,
           stable,
           nightly
         ]
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         rust: [
-          1.65.0,
+          1.68.0,
           stable,
           nightly
         ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Book](https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field)
 
 ## [Unreleased]
 
+### Changed
+- Update MSRV to 1.68
+
 ## [0.13.0] - 2023-07-23
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "acceptxmr"
 version = "0.13.0"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.68"
 license = "MIT OR Apache-2.0"
 description = "Accept monero in your application."
 repository = "https://github.com/busyboredom/acceptxmr"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![BuildStatus](https://github.com/busyboredom/acceptxmr/workflows/CI/badge.svg)](https://img.shields.io/github/actions/workflow/status/busyboredom/acceptxmr/ci.yml?branch=main)
 [![Crates.io](https://img.shields.io/crates/v/acceptxmr.svg)](https://crates.io/crates/acceptxmr)
 [![Documentation](https://docs.rs/acceptxmr/badge.svg)](https://docs.rs/acceptxmr)
-[![MSRV](https://img.shields.io/badge/MSRV-1.65.0-blue)](https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html)
+[![MSRV](https://img.shields.io/badge/MSRV-1.68.0-blue)](https://blog.rust-lang.org/2022/11/03/Rust-1.68.0.html)
 
 # `AcceptXMR`: Accept Monero in Your Application
 


### PR DESCRIPTION
# Description
Update MSRV to 1.68 for transitive `time` dependency.

# Checklist
- [x] Link relevant issue(s).
- [x] Manually test the change.
- [x] Ensure sufficient automated test coverage.
- [x] Update the README.md if necessary.
- [x] Update the CHANGELOG.md if necessary.